### PR TITLE
Fix graph loader for corrupted lines

### DIFF
--- a/analysis/fourier.py
+++ b/analysis/fourier.py
@@ -1,17 +1,20 @@
-import json,datetime,numpy as np, matplotlib.pyplot as plt
-from utils.storage import user_dir
-def _series(uid,param):
-    folder=user_dir(uid)/'mood'; pts=[]
-    if not folder.exists(): return None
-    for fp in folder.glob('mood_*.jsonl'):
-        date=datetime.datetime.strptime(fp.name.split('_')[1],'%Y%m%d').date()
-        with fp.open() as f:
-            for line in f:
-                d=json.loads(line)
-                if param in d and d[param] is not None:
-                    pts.append((date.toordinal(), d[param]))
-    if not pts: return None
-    pts.sort(); return np.array(pts).T
+import datetime
+import numpy as np
+import matplotlib.pyplot as plt
+
+from analysis.generate_plot import _load
+
+
+def _series(uid: int, param: str):
+    df = _load(uid)
+    if df.empty or param not in df.columns:
+        return None
+    df = df.dropna(subset=[param]).sort_values("date")
+    if df.empty:
+        return None
+    x = df["date"].dt.date.map(datetime.date.toordinal).to_numpy()
+    y = df[param].to_numpy()
+    return np.array([x, y])
 def save_fft(uid,param,out):
     import numpy as np
     res=_series(uid,param); 

--- a/handlers/manage.py
+++ b/handlers/manage.py
@@ -2,6 +2,7 @@
 # ───────────────────────────────────────────────────────────
 import re, datetime
 from aiogram import Router, types, Bot
+from aiogram.types import FSInputFile
 from aiogram.filters import Command
 from aiogram.utils.keyboard import InlineKeyboardBuilder
 from handlers import view_dreams
@@ -171,7 +172,7 @@ async def _show_graph(bot: Bot, uid: int, st: GraphState, message: types.Message
         except Exception:
             pass
     if res:
-        msg = await bot.send_photo(uid, open(res, "rb"), reply_markup=kb.as_markup())
+        msg = await bot.send_photo(uid, FSInputFile(res), reply_markup=kb.as_markup())
     else:
         msg = await bot.send_message(uid, "Нет данных.", reply_markup=kb.as_markup())
     st.msg_id = msg.message_id
@@ -279,7 +280,7 @@ async def send_fft(cq: types.CallbackQuery, bot: Bot):
     path = user_dir(cq.from_user.id) / f"{param}_fft.png"
     res = save_fft(cq.from_user.id, param, str(path))
     if res:
-        await bot.send_photo(cq.from_user.id, photo=open(res, "rb"))
+        await bot.send_photo(cq.from_user.id, photo=FSInputFile(res))
     else:
         await bot.send_message(cq.from_user.id, "Нет данных.")
     await cq.answer()


### PR DESCRIPTION
## Summary
- add decryption-aware loader for mood records
- use the loader in Fourier analysis

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6840a6b893c48332ad8289f6bfe183d4