### PR TITLE
Add debug data generator and fix date parsing

### DIFF
--- a/analysis/generate_plot.py
+++ b/analysis/generate_plot.py
@@ -17,7 +17,7 @@ def _load(uid: int) -> pd.DataFrame:
     if folder.exists():
         pwd = get_pass(uid)
         for fp in sorted(folder.glob("mood_*.jsonl")):
-            date = datetime.datetime.strptime(fp.name.split("_")[1], "%Y%m%d").date()
+            file_date = fp.name.split("_")[1]
             with fp.open("rb") as f:
                 for raw in f:
                     try:
@@ -32,7 +32,15 @@ def _load(uid: int) -> pd.DataFrame:
                         if not pwd:
                             continue
                         d = decrypt(d["enc"], pwd) or {}
-                    d.setdefault("date", date)
+                    date_str = d.get("date")
+                    if date_str:
+                        try:
+                            rec_date = datetime.date.fromisoformat(str(date_str))
+                        except ValueError:
+                            rec_date = datetime.datetime.strptime(str(date_str)[:8], "%Y%m%d").date()
+                    else:
+                        rec_date = datetime.datetime.strptime(file_date[:8], "%Y%m%d").date()
+                    d["date"] = rec_date
                     rows.append(d)
     df = pd.DataFrame(rows)
 

--- a/scripts/debug_generator.py
+++ b/scripts/debug_generator.py
@@ -1,0 +1,37 @@
+import random
+import datetime
+from pathlib import Path
+import sys
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+try:
+    from config import PARAMETERS
+    from utils.storage import save_jsonl
+except ModuleNotFoundError:
+    if str(BASE_DIR) not in sys.path:
+        sys.path.append(str(BASE_DIR))
+    from config import PARAMETERS
+    from utils.storage import save_jsonl
+
+
+def gen(uid: int, days: int = 547) -> None:
+    start = datetime.date.today() - datetime.timedelta(days=days)
+    for i in range(days):
+        day = start + datetime.timedelta(days=i)
+        record = {"date": day.isoformat(), "summary": ""}
+        for key, _ in PARAMETERS:
+            if random.random() < 0.1:
+                record[key] = None
+            else:
+                record[key] = random.randint(-3, 3)
+        save_jsonl(uid, "mood", "mood", record)
+
+        dream = {"dream": "", "analysis": "", "metrics": {}, "date": day.isoformat()}
+        save_jsonl(uid, "dreams", "dream", dream)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python debug_generator.py <user_id>")
+        sys.exit(1)
+    gen(int(sys.argv[1]))


### PR DESCRIPTION
## Summary
- generate fake moods and dreams for about 1.5 years
- better handle missing `date` field when reading mood files

## Testing
- `python -m py_compile scripts/debug_generator.py analysis/generate_plot.py`
- `python scripts/debug_generator.py 1` *(fails: ModuleNotFoundError: No module named 'cryptography')*

------
https://chatgpt.com/codex/tasks/task_e_6840bcc7dda483329f612f6f345bcb56