### PR TITLE
Enhance debug data generator

### DIFF
--- a/debug_generator.py
+++ b/debug_generator.py
@@ -3,10 +3,10 @@ import datetime
 import sys
 
 from config import PARAMETERS, CIM_EMOTIONS, EMOTION_COEFF
-from utils.storage import save_json
+from utils.storage import save_json, save_json_named
 
 
-def gen(uid: int, days: int = 547) -> None:
+def gen(uid: int, days: int = 547, use_date_name: bool = False) -> None:
     start = datetime.date.today() - datetime.timedelta(days=days)
     for i in range(days):
         day = start + datetime.timedelta(days=i)
@@ -16,7 +16,11 @@ def gen(uid: int, days: int = 547) -> None:
                 record[key] = None
             else:
                 record[key] = random.randint(-3, 3)
-        save_json(uid, "mood", "mood", record)
+        if use_date_name:
+            fname = f"mood_{day.strftime('%Y%m%d')}.json"
+            save_json_named(uid, "mood", fname, record)
+        else:
+            save_json(uid, "mood", "mood", record)
 
         emotions = random.sample(CIM_EMOTIONS, k=random.randint(1, 3))
         intensity = round(random.uniform(0.5, 3.0), 2)
@@ -27,7 +31,11 @@ def gen(uid: int, days: int = 547) -> None:
             metrics["cim_score"] = cim_score
 
         dream = {"dream": "", "analysis": "", "metrics": metrics, "date": day.isoformat()}
-        save_json(uid, "dreams", "dream", dream)
+        if use_date_name:
+            fname_d = f"dream_{day.strftime('%Y%m%d')}.json"
+            save_json_named(uid, "dreams", fname_d, dream)
+        else:
+            save_json(uid, "dreams", "dream", dream)
 
 
 if __name__ == "__main__":

--- a/utils/storage.py
+++ b/utils/storage.py
@@ -29,6 +29,23 @@ def save_json(uid: int, sub: str, prefix: str, data: Dict[str, Any]) -> Path:
     return fp
 
 
+# ─────────────── запись в указанный JSON-файл ───────────────
+def save_json_named(uid: int, sub: str, name: str, data: Dict[str, Any]) -> Path:
+    """Write JSON data to a file with an explicit name."""
+    folder = user_dir(uid) / sub
+    folder.mkdir(exist_ok=True)
+
+    if not name.endswith(".json"):
+        name += ".json"
+
+    pwd = get_pass(uid)
+    payload = {"enc": encrypt(data, pwd)} if pwd else data
+
+    fp = folder / name
+    fp.write_text(json.dumps(payload, ensure_ascii=False) + "\n", encoding="utf-8")
+    return fp
+
+
 # ─────────── чтение всех строк с защитой от «кривых» ───────
 def load_records(uid: int, sub: str) -> List[Dict[str, Any]]:
     """


### PR DESCRIPTION
## Summary
- allow explicit file names when generating debug data
- support reading mood files based on record dates instead of filenames

## Testing
- `python -m py_compile debug_generator.py analysis/generate_plot.py utils/storage.py`

------
https://chatgpt.com/codex/tasks/task_e_6840c5acc8f48332944267c5e46ef7c6