### PR TITLE
Fix menu edit and add averaged plot

### DIFF
--- a/handlers/manage.py
+++ b/handlers/manage.py
@@ -476,5 +476,5 @@ async def exp(cq: types.CallbackQuery, bot: Bot):
 # ───── Назад ──────────────────────────────────────────────
 @router.callback_query(lambda c: c.data == "mg_back")
 async def back(cq: types.CallbackQuery):
-    await cq.message.edit_text("Меню:", reply_markup=main_kb())
+    await _edit(cq.message, "Меню:", main_kb())
     await cq.answer()


### PR DESCRIPTION
## Summary
- handle captioned messages when returning to menu
- average graph data with dynamic window and show deviation

## Testing
- `python -m py_compile handlers/manage.py analysis/generate_plot.py`

------
https://chatgpt.com/codex/tasks/task_e_6840cc1db2c08332b5a4f47ea5e8c66c