### PR TITLE
Fix graphs and improve dream recording

### DIFF
--- a/analysis/generate_plot.py
+++ b/analysis/generate_plot.py
@@ -81,10 +81,10 @@ def plot_multi(uid: int, params: list[str], period: str, out: str, page: int = 0
     if df.empty:
         return None
 
-    df = df.dropna(subset=params).sort_values("date")
+    df = df.sort_values("date")
     df.set_index("date", inplace=True)
 
-    daily_mean = df[params].resample("1D").mean()
+    daily_mean = df[params].resample("1D").mean().dropna(how="all")
     if daily_mean.empty:
         return None
 
@@ -93,8 +93,8 @@ def plot_multi(uid: int, params: list[str], period: str, out: str, page: int = 0
         span = (daily_mean.index[-1] - daily_mean.index[0]).days + 1
         step = max(1, ceil(span / 60))
 
-    mean = df[params].resample(f"{step}D").mean()
-    std = df[params].resample(f"{step}D").std().fillna(0)
+    mean = daily_mean.resample(f"{step}D").mean()
+    std = daily_mean.resample(f"{step}D").std().fillna(0)
 
     plt.figure()
     for p in params:

--- a/handlers/manage.py
+++ b/handlers/manage.py
@@ -59,6 +59,7 @@ def main_kb() -> types.InlineKeyboardMarkup:
     kb.button(text="🗓 Пропуски",      callback_data="mg_missed")
     kb.button(text="🕒 Напоминания",   callback_data="mg_time")
     kb.button(text="📝 Чек-ин",        callback_data="mg_now")
+    kb.button(text="🌙 Записать сон",  callback_data="mg_dream_now")
     kb.button(text="🔑 Пароль",        callback_data="mg_pass")      # ← новая
     kb.button(text="📦 Экспорт",       callback_data="mg_export")
     kb.adjust(1)
@@ -112,6 +113,14 @@ async def dreams_button(cq: types.CallbackQuery, bot: Bot):
 async def now_ci(cq: types.CallbackQuery, bot: Bot):
     await bot.send_message(cq.from_user.id, "Быстрый чек-ин.")
     await mood.start(bot, cq.from_user.id)
+    await cq.answer()
+
+
+# ───── кнопка Запись сна сейчас ───────────────────────────
+@router.callback_query(lambda c: c.data == "mg_dream_now")
+async def dream_now(cq: types.CallbackQuery, bot: Bot):
+    from handlers import dreams
+    await dreams.start_record(bot, cq.from_user.id)
     await cq.answer()
 
 
@@ -217,7 +226,7 @@ async def g_new_param(cq: types.CallbackQuery):
         kb.button(text=l, callback_data=f"gp_add_{k}")
     kb.button(text="⬅️", callback_data="mg_graph")
     kb.adjust(2)
-    await _edit(cq.message, "Параметр:", kb.as_markup())
+    await cq.bot.send_message(cq.from_user.id, "Параметр:", reply_markup=kb.as_markup())
     if st:
         st.params = []
     await cq.answer()
@@ -476,5 +485,9 @@ async def exp(cq: types.CallbackQuery, bot: Bot):
 # ───── Назад ──────────────────────────────────────────────
 @router.callback_query(lambda c: c.data == "mg_back")
 async def back(cq: types.CallbackQuery):
-    await _edit(cq.message, "Меню:", main_kb())
+    try:
+        await cq.message.delete()
+    except Exception:
+        pass
+    await cq.message.answer("Меню:", reply_markup=main_kb())
     await cq.answer()

--- a/handlers/missed.py
+++ b/handlers/missed.py
@@ -44,10 +44,5 @@ async def start_back_ci(cq: types.CallbackQuery, bot: Bot):
 @router.callback_query(lambda c: c.data.startswith('dr_'))
 async def start_back_dream(cq: types.CallbackQuery, bot: Bot):
     date=cq.data.split('_',1)[1]
-
-    await bot.send_message(
-        cq.from_user.id,
-        f"Сон за {date}\nОтправь текст сообщением или кнопка:",
-        reply_markup=dreams.dream_kb()
-    )
-    dreams._waiting[cq.from_user.id] = date  # ← ставим флажок
+    await bot.send_message(cq.from_user.id, f"Сон за {date}")
+    await dreams.start_record(bot, cq.from_user.id, date)


### PR DESCRIPTION
## Summary
- handle missing values when combining mood and CIM metrics
- remove menu on back action instead of editing photo message
- add quick sleep entry from main menu
- support multistep dream recording with timeout
- adjust missed-date dream entry to new API

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6840d024b3a48332a11e7e9c0ac79128