### PR TITLE
Add settings menu with custom parameters

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -30,7 +30,7 @@ async def setup_commands():
         BotCommand(command="menu", description="Меню"),
         BotCommand(command="checkin", description="Быстрый чек-ин"),
         BotCommand(command="dream", description="Записать сон"),
-        BotCommand(command="dreams", description="Список снов"),
+        BotCommand(command="dreams", description="Архив снов"),
         BotCommand(command="set", description="Время уведомлений"),
         BotCommand(command="login", description="Ввести пароль"),
         BotCommand(command="register", description="Новый пароль"),


### PR DESCRIPTION
## Summary
- rename menu item to "Архив снов"
- add built-in parameter "Либидо"
- allow per-user extra check-in parameters via settings
- introduce "Настройки" menu with reminders, password, export and add-param
- smooth multi-parameter graphs

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6840d1b262948332aff6045f5ba56915