### PR TITLE
Fix dreams handling, FFT and graphs

### DIFF
--- a/analysis/fourier.py
+++ b/analysis/fourier.py
@@ -15,13 +15,38 @@ def _series(uid: int, param: str):
     x = df["date"].dt.date.map(datetime.date.toordinal).to_numpy()
     y = df[param].to_numpy()
     return np.array([x, y])
-def save_fft(uid,param,out):
-    import numpy as np
-    res=_series(uid,param); 
-    if res is None: return None
-    x,y=res
-    days=np.arange(x[0],x[-1]+1)
-    y=np.interp(days,x,y)-np.mean(y)
-    amp=np.abs(np.fft.rfft(y)); freq=np.fft.rfftfreq(len(days),d=1)
-    import matplotlib.pyplot as plt
-    plt.figure(); plt.plot(freq[1:],amp[1:]); plt.title(f"FFT {param}"); plt.savefig(out); plt.close(); return out
+def save_fft(uid: int, param: str, out: str):
+    res = _series(uid, param)
+    if res is None:
+        return None
+
+    x, y = res
+    days = np.arange(x[0], x[-1] + 1)
+    y = np.interp(days, x, y) - np.mean(y)
+
+    amp = np.abs(np.fft.rfft(y))
+    freq = np.fft.rfftfreq(len(days), d=1)
+
+    plt.figure()
+    plt.plot(freq[1:], amp[1:])
+    plt.title(f"FFT {param}")
+
+    if len(amp) > 4:
+        idx = np.argsort(amp[1:])[-3:][::-1]
+        for i in idx:
+            f = freq[1:][i]
+            if f == 0:
+                continue
+            T = 1 / f
+            if T <= 90:
+                label = f"{round(T)} дн"
+            elif T <= 365 * 3:
+                label = f"{round(T/30)} мес"
+            else:
+                label = f"{round(T/365, 1)} лет"
+            plt.plot(f, amp[1:][i], "ro")
+            plt.text(f, amp[1:][i], label)
+
+    plt.savefig(out)
+    plt.close()
+    return out

--- a/analysis/generate_plot.py
+++ b/analysis/generate_plot.py
@@ -103,13 +103,22 @@ def plot_multi(uid: int, params: list[str], period: str, out: str, page: int = 0
     plt.figure()
     for p in params:
         if p in mean.columns:
+            series = mean[p].dropna()
+            if series.empty:
+                continue
             if len(params) > 1:
-                plt.plot(mean.index, mean[p], label=p)
+                plt.plot(series.index, series, label=p)
             else:
                 if step > 1:
-                    plt.errorbar(mean.index, mean[p], yerr=std[p], fmt="-o", label=p)
+                    plt.errorbar(
+                        series.index,
+                        series,
+                        yerr=std[p].loc[series.index],
+                        fmt="-o",
+                        label=p,
+                    )
                 else:
-                    plt.plot(mean.index, mean[p], "-o", label=p)
+                    plt.plot(series.index, series, "-o", label=p)
 
     # ───── оформление оси X ────────────────────────────────
     months_nom = [

--- a/handlers/manage.py
+++ b/handlers/manage.py
@@ -459,7 +459,7 @@ async def fft_param(cq: types.CallbackQuery):
     await cq.answer()
 
 
-@router.callback_query(lambda c: re.match(r"f_\\w+", c.data))
+@router.callback_query(lambda c: c.data.startswith("f_"))
 async def send_fft(cq: types.CallbackQuery, bot: Bot):
     param = cq.data[2:]
     path = user_dir(cq.from_user.id) / f"{param}_fft.png"
@@ -489,7 +489,11 @@ async def time_view(cq: types.CallbackQuery):
 @router.callback_query(lambda c: c.data == "mg_export")
 async def exp(cq: types.CallbackQuery, bot: Bot):
     path = export(cq.from_user.id)
-    await bot.send_document(cq.from_user.id, open(path, "rb"), caption="Экспорт")
+    await bot.send_document(
+        cq.from_user.id,
+        FSInputFile(path),
+        caption="Экспорт",
+    )
     await cq.answer()
 
 
@@ -506,6 +510,8 @@ async def receive_param(msg: types.Message):
     label = msg.text.strip()
     add_custom_param(msg.from_user.id, label)
     await msg.reply(f"Добавлен параметр: {label}")
+    from handlers.manage import main_kb
+    await msg.answer("Меню:", reply_markup=main_kb())
 
 
 # ───── кнопка Пропуски ────────────────────────────────────


### PR DESCRIPTION
## Summary
- record empty dreams correctly with date/metrics
- prevent 'dream_end' artifacts and skip GPT when text absent
- show added parameters in menu after adding
- fix export to use `FSInputFile`
- draw FFT peaks with period labels
- handle FFT callbacks reliably
- avoid line gaps on graphs

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6840d899d2c88332a942f75573e00b30