### PR TITLE
Handle long DreamGPT messages

### DIFF
--- a/handlers/dreams.py
+++ b/handlers/dreams.py
@@ -9,6 +9,7 @@ from aiogram.utils.keyboard import InlineKeyboardBuilder
 
 from Token import AUTHORIZED_USER_IDS
 from utils.storage import save_json
+from utils import send_long
 
 router = Router()
 
@@ -77,7 +78,8 @@ async def _finish(uid: int, bot: Bot):
     text = "\n".join(info["msgs"]).strip()
     if text:
         analysis, metrics = await _commit(uid, text, info["date"])
-        await bot.send_message(
+        await send_long(
+            bot,
             uid,
             f"🌓 Анализ сна:\n{analysis}{_fmt_metrics(metrics)}",
         )
@@ -169,7 +171,12 @@ async def cmd_dream(msg: types.Message):
     text = msg.text.replace("/dream", "", 1).strip()
     if text:
         analysis, metrics = await _commit(msg.from_user.id, text, None)
-        await msg.reply(f"🌓 Анализ сна:\n{analysis}{_fmt_metrics(metrics)}")
+        await send_long(
+            msg.bot,
+            msg.chat.id,
+            f"🌓 Анализ сна:\n{analysis}{_fmt_metrics(metrics)}",
+            reply_to_message_id=msg.message_id,
+        )
         from handlers.manage import main_kb
         await msg.answer("Меню:", reply_markup=main_kb())
     else:

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,1 +1,20 @@
+from aiogram import Bot
 
+MAX_MESSAGE_LENGTH = 4096
+
+async def send_long(bot: Bot, chat_id: int, text: str, **kwargs) -> None:
+    """Send text in several messages if it exceeds Telegram limit."""
+    remaining = text
+    first = True
+    while remaining:
+        chunk = remaining[:MAX_MESSAGE_LENGTH]
+        if len(chunk) == MAX_MESSAGE_LENGTH:
+            cut = max(chunk.rfind('\n'), chunk.rfind(' '))
+            if cut <= 0 or cut < MAX_MESSAGE_LENGTH - 100:
+                cut = MAX_MESSAGE_LENGTH
+            chunk = remaining[:cut]
+        await bot.send_message(chat_id, chunk, **kwargs)
+        if first and 'reply_to_message_id' in kwargs:
+            del kwargs['reply_to_message_id']
+            first = False
+        remaining = remaining[len(chunk):].lstrip('\n')


### PR DESCRIPTION
## Summary
- split oversized GPT dream analysis into multiple Telegram messages
- add `send_long` helper to handle oversized text

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840f36bdd3483328360228ddd2fe099