### PR TITLE
Update dream logic and timestamps

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -34,7 +34,8 @@ async def setup_commands():
     await bot.set_my_commands(cmds)
 
 async def morning(uid:int):
-    from handlers.dreams import dream_kb
+    from handlers.dreams import dream_kb, register_prompt
+    register_prompt(uid)
     await bot.send_message(uid,"Доброе утро! /dream или кнопка:", reply_markup=dream_kb())
 async def evening(uid:int):
     await bot.send_message(uid,"Вечерний чек‑ин.")

--- a/handlers/mood.py
+++ b/handlers/mood.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import datetime
 from pathlib import Path
 from typing import Dict, Optional
 
@@ -31,8 +32,9 @@ def build_kb(param: str) -> types.InlineKeyboardMarkup:
 
 
 async def start(bot: Bot, uid: int, backdate: Optional[str] = None) -> None:
-    params=user_parameters(uid)
-    _state[uid] = {"index": 0, "data": {"date": backdate}, "file": None, "params":params}
+    params = user_parameters(uid)
+    date_iso = backdate or datetime.date.today().isoformat()
+    _state[uid] = {"index": 0, "data": {"date": date_iso}, "file": None, "params": params}
     k, label = params[0]
     await bot.send_message(uid, f"{label}  (-3…3):", reply_markup=build_kb(k))
 

--- a/handlers/view_dreams.py
+++ b/handlers/view_dreams.py
@@ -19,8 +19,15 @@ PAGE = 16  # сколько дат на одной странице
 def dates_with_dreams(uid: int) -> List[datetime.date]:
     recs = load_records(uid, "dreams")
     out = []
+    skip = (
+        "Не запомнил сон",
+        "Лень записывать",
+        "Помню урывками",
+        "",
+    )
     for r in recs:
-        if r.get("dream") and not r["dream"].startswith("Не запомнил"):
+        txt = r.get("dream") or ""
+        if txt and not any(txt.startswith(s) for s in skip):
             date_str = r.get("date")
             if not date_str:
                 continue
@@ -78,13 +85,14 @@ async def change_page(cq: types.CallbackQuery):
 @router.callback_query(lambda c: c.data.startswith("showdream_"))
 async def show_one(cq: types.CallbackQuery, bot: Bot):
     date_iso = cq.data.split("_", 1)[1]
-    recs = load_records(cq.from_user.id, "dreams")
-    rec = next((r for r in recs if r.get("date") == date_iso), None)
-    if not rec:
-        await cq.answer("Запись не найдена"); return
+    recs = [r for r in load_records(cq.from_user.id, "dreams") if r.get("date") == date_iso]
+    if not recs:
+        await cq.answer("Запись не найдена")
+        return
 
-    await bot.send_message(
-        cq.from_user.id,
-        f"🌙 Сон ({date_iso}):\n{rec['dream']}\n\n🌓 {rec['analysis']}"
-    )
+    for rec in recs:
+        await bot.send_message(
+            cq.from_user.id,
+            f"🌙 Сон ({date_iso}):\n{rec['dream']}\n\n🌓 {rec['analysis']}"
+        )
     await cq.answer()


### PR DESCRIPTION
## Summary
- mark sleep reminders when sending morning message
- store check-in date when bot asks
- keep dream prompt date across responses
- hide placeholder dreams from archive and show multiple per day

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68470cd4897c8332a4274004b94947d0